### PR TITLE
Feature/bootstrap from system space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 
 # Mac stuff
 .DS_Store
+
+# Generated test files during test runs
+test_files/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-03-04
+  
+### Added
+
+- Added low level certificate functions to the SDK
+  - Return keys and certificates as DER format
+  - Create client.key, client.crt and ca.crt in a folder
+- Added logging when reading required env variables
+
+### Changed
+- **Breaking change:**  Pem formatted certificates and keys returns a Result< String > instead of a string
+- **Breaking change:**  Return certificates in a Result < Cert > instead of a Option< Cert >
+- **Breaking change:**  Return producer config in a Result < ClientConfig > instead of a ClientConfig
+- Fix dsh::Properties::new() when feature 'local' is disabled
+
+### Removed
+- Removed unused dependency in Cargo.toml
+  
+
 ## [0.1.3] - 2024-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 ### Added
 
-- Added low level certificate functions to the SDK
+- Make dsh::Properties lazily available dsh::Properties::get() 
+- New low level certificate functions to the SDK
   - Return keys and certificates as DER format
   - Create client.key, client.crt and ca.crt in a folder
-- Added logging when reading required env variables
+- Logging when reading required env variables
+- Task_id to Properties
+- Some missing unit tests
 
 ### Changed
+Most breaking changes are related to the new low level API and do not impact normal use of the SDK.
+- Add deprecation warning to dsh::Properties::new() and dsh::Properties::new_blocking() to use dsh::Properties::get() instead
+- **Breaking change:**  Return producer config in a Result < ClientConfig > instead of a ClientConfig
 - **Breaking change:**  Pem formatted certificates and keys returns a Result< String > instead of a string
 - **Breaking change:**  Return certificates in a Result < Cert > instead of a Option< Cert >
-- **Breaking change:**  Return producer config in a Result < ClientConfig > instead of a ClientConfig
+- **Breaking change:**  Return borrowed references from Datastream struct instead of owned values.
 - Fix dsh::Properties::new() when feature 'local' is disabled
+- Make initialization true blocking
+- Improved logging
 
 ### Removed
 - Removed unused dependency in Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Return keys and certificates as DER format
   - Create client.key, client.crt and ca.crt in a folder
 - Write datastreams.json as file to a folder
+- Read DSH_SECRET_TOKEN_PATH from environment and read secret token from file as fallback for DSH_SECRET_TOKEN
+  - Required for running in system space
 - Logging when reading required env variables
 - Task_id to Properties
 - Some missing unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-03-04
+## [0.2.0] - 2024-03-06
   
 ### Added
 
@@ -13,19 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New low level certificate functions to the SDK
   - Return keys and certificates as DER format
   - Create client.key, client.crt and ca.crt in a folder
+- Write datastreams.json as file to a folder
 - Logging when reading required env variables
 - Task_id to Properties
 - Some missing unit tests
 
 ### Changed
 Most breaking changes are related to the new low level API and do not impact normal use of the SDK.
-- Add deprecation warning to dsh::Properties::new() and dsh::Properties::new_blocking() to use dsh::Properties::get() instead
+- Add deprecation warning to dsh::Properties::new() to use dsh::Properties::get() instead
 - **Breaking change:**  Return producer config in a Result < ClientConfig > instead of a ClientConfig
 - **Breaking change:**  Pem formatted certificates and keys returns a Result< String > instead of a string
 - **Breaking change:**  Return certificates in a Result < Cert > instead of a Option< Cert >
 - **Breaking change:**  Return borrowed references from Datastream struct instead of owned values.
 - Fix dsh::Properties::new() when feature 'local' is disabled
-- Make initialization true blocking
+- Make initialization blocking
 - Improved logging
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ opt-level = 3
 [features]
 default = ["bootstrap", "graceful_shutdown", "local", "metrics", "rdkafka-ssl"]
 full = ["bootstrap", "graceful_shutdown", "local", "metrics", "rdkafka-ssl", "dlq"]
-bootstrap = ["picky", "serde_json", "reqwest", "tokio"]
+bootstrap = ["picky", "serde_json", "reqwest"]
 local = ["bootstrap"]
 metrics =  ["prometheus", "warp", "lazy_static"]
 dlq = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 name = "dsh_sdk"
 readme = "README.md"
 repository = "https://github.com/kpn-dsh/dsh-sdk-platform-rs"
-version = "0.1.3"
+version = "0.2.0"
 
 [package.metadata.docs.rs]
 features = ["full"]
@@ -21,7 +21,6 @@ features = ["full"]
 tokio = { version = "^1.35", features = ["signal", "sync", "time", "macros", "rt-multi-thread"], optional = true}
 tokio-util = {version = "0.7", optional = true}
 rdkafka =  { version = "0.36", features =  ["cmake-build"], optional = true}
-rustls = { version = "0.22.2", optional = true}
 serde = { version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", optional = true}
 picky = { version =  "7.0.0-rc.8", default-features = false, features = ["x509"], optional = true}
@@ -35,7 +34,7 @@ lazy_static  = { version = "1.4", optional = true}
 [features]
 default = ["bootstrap", "graceful_shutdown", "local", "metrics", "rdkafka-ssl"]
 full = ["bootstrap", "graceful_shutdown", "local", "metrics", "rdkafka-ssl", "dlq"]
-bootstrap = ["rustls", "picky", "serde_json", "reqwest", "tokio"]
+bootstrap = ["picky", "serde_json", "reqwest", "tokio"]
 local = ["bootstrap"]
 metrics =  ["prometheus", "warp", "lazy_static"]
 dlq = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ prometheus = { version = "0.13", features = ["process"], optional = true }
 warp = { version = "^0.3.4", optional = true}
 lazy_static  = { version = "1.4", optional = true}
 
+[profile.dev.package.num-bigint-dig]
+opt-level = 3
+
 [features]
 default = ["bootstrap", "graceful_shutdown", "local", "metrics", "rdkafka-ssl"]
 full = ["bootstrap", "graceful_shutdown", "local", "metrics", "rdkafka-ssl", "dlq"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rdkafka =  { version = "0.36", features =  ["cmake-build"], optional = true}
 serde = { version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", optional = true}
 picky = { version =  "7.0.0-rc.8", default-features = false, features = ["x509"], optional = true}
-reqwest = { version = "0.11" , default-features = false, features = ["rustls-tls", "tokio-rustls"], optional = true}
+reqwest = { version = "0.11" , default-features = false, features = ["rustls-tls", "blocking"], optional = true}
 log =  "0.4"
 thiserror = "1.0"
 prometheus = { version = "0.13", features = ["process"], optional = true }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Description
 This library can be used to interact with the DSH Platform. It is intended to be used as a base for services that will be used to interact with DSH. It is not intended to be used directly. Features include:
 - Connect to DSH 
-- Fetch Kafka Properties (datastream)
+- Fetch Kafka Properties and certificates
 - Common functions 
   - Preconfigured RDKafka client config
   - Preconfigured Reqwest client config (for schema store)
@@ -37,12 +37,12 @@ See [feature flags](#feature-flags) for more information on the available featur
 To use this SDK in your project
 ```rust
 use dsh_sdk::dsh::Properties;
+use dsh_sdk::rdkafka::consumer::{Consumer, StreamConsumer};
 
-#[tokio::main]
-async fn main() {
-    let dsh_properties = Properties::new().await.unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>>{
+    let dsh_properties = Properties::get();
     // get a rdkafka consumer config for example
-    let consumer_config = dsh_properties.consumer_rdkafka_config().create().unwrap();
+    let consumer: StreamConsumer = dsh_properties.consumer_rdkafka_config()?.create()?;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ To use this SDK with the default features in your project, add the following to 
   
 ```toml
 [dependencies]
-dsh_sdk = "0.1"
+dsh_sdk = "0.2"
 ```
 
 However, if you would like to use only specific features, you can specify them in your Cargo.toml file. For example, if you would like to use only the bootstrap feature, add the following to your Cargo.toml file:
   
 ```toml
 [dependencies]
-dsh_sdk = { version = "0.1", default-features = false, features = ["bootstrap"] }
+dsh_sdk = { version = "0.2", default-features = false, features = ["bootstrap"] }
 ```
 
 See [feature flags](#feature-flags) for more information on the available features.

--- a/example_dsh_service/Cargo.toml
+++ b/example_dsh_service/Cargo.toml
@@ -5,7 +5,7 @@ description = "An example of DSH service using the dsh-sdk crate"
 edition = "2021"
 
 [dependencies]
-dsh_sdk = { version = "0.1", features = ["rdkafka-ssl-vendored"] }
+dsh_sdk = { version = "0.2", features = ["rdkafka-ssl-vendored"] }
 log = "0.4"
 env_logger = "0.11"
 tokio = { version = "^1.35", features = ["full"] }

--- a/example_dsh_service/src/main.rs
+++ b/example_dsh_service/src/main.rs
@@ -60,16 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Create a new properties instance (connects to the DSH server and fetches the datastream)
-     let dsh_properties = match Properties::new().await {
-         Ok(properties) => {
-             info!("Successfully initiated SDK properties");
-             Ok(properties)
-         }
-         Err(e) => {
-             error!("Error while initiating SDK properties: {:?}", e);
-             Err(e)
-         }
-     }?;
+     let dsh_properties = Properties::get()?;
 
     // Get the configured topics from env variable TOPICS (comma separated)
     let topis_string = std::env::var("TOPICS").expect("TOPICS env variable not set");

--- a/example_dsh_service/src/main.rs
+++ b/example_dsh_service/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Create a new properties instance (connects to the DSH server and fetches the datastream)
-     let dsh_properties = Properties::get()?;
+     let dsh_properties = Properties::get();
 
     // Get the configured topics from env variable TOPICS (comma separated)
     let topis_string = std::env::var("TOPICS").expect("TOPICS env variable not set");

--- a/example_dsh_service/src/main.rs
+++ b/example_dsh_service/src/main.rs
@@ -1,5 +1,3 @@
-use log::{error, info};
-
 use dsh_sdk::dsh::Properties;
 use dsh_sdk::graceful_shutdown::Shutdown;
 
@@ -60,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Create a new properties instance (connects to the DSH server and fetches the datastream)
-     let dsh_properties = Properties::get();
+     let dsh_properties = Properties::get()?;
 
     // Get the configured topics from env variable TOPICS (comma separated)
     let topis_string = std::env::var("TOPICS").expect("TOPICS env variable not set");

--- a/example_dsh_service/src/main.rs
+++ b/example_dsh_service/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Create a new properties instance (connects to the DSH server and fetches the datastream)
-     let dsh_properties = Properties::get()?;
+     let dsh_properties = Properties::get();
 
     // Get the configured topics from env variable TOPICS (comma separated)
     let topis_string = std::env::var("TOPICS").expect("TOPICS env variable not set");

--- a/examples/produce_consume.rs
+++ b/examples/produce_consume.rs
@@ -38,7 +38,7 @@ async fn consume(consumer: &mut StreamConsumer, topic: &str) {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new DSH Properties instance (requires local_datastreams.json in root of project, as it runs in local mode)
-    let dsh_properties = Properties::new().await?;
+    let dsh_properties = Properties::get().await?;
 
     // Define your topic
     let topic = "scratch.local.local-tenant";

--- a/examples/produce_consume.rs
+++ b/examples/produce_consume.rs
@@ -38,7 +38,7 @@ async fn consume(consumer: &mut StreamConsumer, topic: &str) {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new DSH Properties instance (requires local_datastreams.json in root of project, as it runs in local mode)
-    let dsh_properties = Properties::get().await?;
+    let dsh_properties = Properties::get()?;
 
     // Define your topic
     let topic = "scratch.local.local-tenant";

--- a/examples/produce_consume.rs
+++ b/examples/produce_consume.rs
@@ -38,7 +38,7 @@ async fn consume(consumer: &mut StreamConsumer, topic: &str) {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new DSH Properties instance (requires local_datastreams.json in root of project, as it runs in local mode)
-    let dsh_properties = Properties::get()?;
+    let dsh_properties = Properties::get();
 
     // Define your topic
     let topic = "scratch.local.local-tenant";

--- a/examples/produce_consume.rs
+++ b/examples/produce_consume.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let topic = "scratch.local.local-tenant";
 
     // Create a new producer based on the properties default config
-    let mut producer: FutureProducer = dsh_properties.producer_rdkafka_config().create()?;
+    let mut producer: FutureProducer = dsh_properties.producer_rdkafka_config()?.create()?;
 
     // Produce messages towards topic
     produce(&mut producer, topic).await;

--- a/src/dlq.rs
+++ b/src/dlq.rs
@@ -243,7 +243,13 @@ impl Dlq {
     }
 
     fn build_producer(dsh_prop: &Properties) -> Result<FutureProducer, rdkafka::error::KafkaError> {
-        let producer_config = dsh_prop.producer_rdkafka_config();
+        let producer_config = match dsh_prop.producer_rdkafka_config() {
+            Ok(config) => config,
+            Err(e) => {
+                error!("Error creating producer config");
+                return Err(rdkafka::error::KafkaError::ClientCreation(format!("Error creating producer config: {}", e)));
+            }
+        };
         producer_config.create()
     }
 }

--- a/src/dlq.rs
+++ b/src/dlq.rs
@@ -247,7 +247,10 @@ impl Dlq {
             Ok(config) => config,
             Err(e) => {
                 error!("Error creating producer config");
-                return Err(rdkafka::error::KafkaError::ClientCreation(format!("Error creating producer config: {}", e)));
+                return Err(rdkafka::error::KafkaError::ClientCreation(format!(
+                    "Error creating producer config: {}",
+                    e
+                )));
             }
         };
         producer_config.create()

--- a/src/dsh/bootstrap.rs
+++ b/src/dsh/bootstrap.rs
@@ -7,9 +7,10 @@
 //! ## Note
 //!
 //! This module is not intended to be used directly, but through the `Properties` struct. It will
-//! ayways be used when creating a new `Properties` struct. If this module returns an error, it defaults
-//! to the local_datastreams.json file, so it can be used in a local environment. (when feature `local`
-//! is enabled)
+//! always be used when getting a `Properties` struct vja dsh::Properties::get(). 
+//! 
+//! If this module returns an error, it defaults to the local_datastreams.json file, so it can be used 
+//! in a local environment. (when feature `local` is enabled)
 //!
 //! ## Example
 //! ```

--- a/src/dsh/bootstrap.rs
+++ b/src/dsh/bootstrap.rs
@@ -46,6 +46,7 @@ impl Properties {
         Ok(Self {
             client_id: dsh_config.task_id.to_string(),
             tenant_name: dsh_config.tenant_name.to_string(),
+            task_id: dsh_config.task_id.to_string(),
             datastream,
             certificates: Some(certificates),
         })

--- a/src/dsh/bootstrap.rs
+++ b/src/dsh/bootstrap.rs
@@ -39,9 +39,8 @@ impl Properties {
         let dn = Dn::parse_string(&dn)?;
         let certificates = Cert::new(dn, &dsh_config, &client)?;
         let client_with_cert = certificates.reqwest_blocking_client_config()?.build()?;
-        let datastreams_string = DshCall::Datastream(&dsh_config)
-            .perform_call(&client_with_cert)
-            ?;
+        let datastreams_string =
+            DshCall::Datastream(&dsh_config).perform_call(&client_with_cert)?;
         let datastream: Datastream = serde_json::from_str(&datastreams_string)?;
         Ok(Self {
             client_id: dsh_config.task_id.to_string(),
@@ -290,8 +289,8 @@ mod tests {
             DshCall::Dn(&dsh_config).request_builder("https://test_host", &Client::new());
         let request = builder.build().unwrap();
         assert_eq!(request.method().as_str(), "GET");
-        let builder: reqwest::blocking::RequestBuilder = DshCall::Datastream(&dsh_config)
-            .request_builder("https://test_host", &Client::new());
+        let builder: reqwest::blocking::RequestBuilder =
+            DshCall::Datastream(&dsh_config).request_builder("https://test_host", &Client::new());
         let request = builder.build().unwrap();
         assert_eq!(request.method().as_str(), "GET");
         let pem = picky::pem::Pem::new("test_type", "test".as_bytes());
@@ -336,9 +335,7 @@ mod tests {
             dsh_ca_certificate: "test_ca_certificate".to_string(),
         };
         // call the function
-        let response = DshCall::Dn(&dsh_config)
-            .perform_call(&client)
-            .unwrap();
+        let response = DshCall::Dn(&dsh_config).perform_call(&client).unwrap();
         assert_eq!(response, dn);
     }
 

--- a/src/dsh/bootstrap.rs
+++ b/src/dsh/bootstrap.rs
@@ -376,11 +376,8 @@ mod tests {
         let test_token_dir = format!("{}/test_token", test_token_dir);
         let _ = std::fs::remove_file(&test_token_dir);
         env::set_var("DSH_SECRET_TOKEN_PATH", &test_token_dir);
-        let result = DshConfig::new().unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            "IO Error: The system cannot find the file specified. (os error 2)".to_string()
-        );
+        let result = DshConfig::new();
+        assert!(result.is_err());
         std::fs::write(test_token_dir.as_str(), "test_token_from_file").unwrap();
         let dsh_config = DshConfig::new().unwrap();
         assert_eq!(dsh_config.dsh_secret_token, "test_token_from_file");

--- a/src/dsh/bootstrap.rs
+++ b/src/dsh/bootstrap.rs
@@ -7,9 +7,9 @@
 //! ## Note
 //!
 //! This module is not intended to be used directly, but through the `Properties` struct. It will
-//! always be used when getting a `Properties` struct vja dsh::Properties::get(). 
-//! 
-//! If this module returns an error, it defaults to the local_datastreams.json file, so it can be used 
+//! always be used when getting a `Properties` struct vja dsh::Properties::get().
+//!
+//! If this module returns an error, it defaults to the local_datastreams.json file, so it can be used
 //! in a local environment. (when feature `local` is enabled)
 //!
 //! ## Example

--- a/src/dsh/bootstrap.rs
+++ b/src/dsh/bootstrap.rs
@@ -92,7 +92,7 @@ impl DshConfig {
                 // if DSH_SECRET_TOKEN is not set, try to read it from a file (for system space applications)
                 info!("trying to read DSH_SECRET_TOKEN from file");
                 let secret_token_path = Self::get_env_var("DSH_SECRET_TOKEN_PATH")?;
-                let path  = std::path::PathBuf::from(secret_token_path);
+                let path = std::path::PathBuf::from(secret_token_path);
                 std::fs::read_to_string(path)?
             }
         };

--- a/src/dsh/certificates.rs
+++ b/src/dsh/certificates.rs
@@ -1,8 +1,38 @@
+//! This module holds the certificate struct and its methods.
+//!
+//! The certificate struct holds the DSH CA certificate, the DSH Kafka certificate and
+//! the private key. It also has methods to create a reqwest client with the DSH Kafka
+//! certificate included and to retrieve the certificates and keys as PEM strings. Also
+//! it is possible to create the ca.crt, client.pem, and client.key files in a desired
+//! directory.
+//!
+//! ## Create files
+//!
+//! To create the ca.crt, client.pem, and client.key files in a desired directory, use the
+//! `to_files` method.
+//! ```no_run
+//! use dsh_sdk::dsh::Properties;
+//! use std::path::PathBuf;
+//! #
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>>{
+//! let dsh_properties = Properties::new().await?;
+//! let directory = PathBuf::from("dir");
+//! dsh_properties.certificates()?.to_files(&directory)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Reqwest Client
+//!
+//! With this request client we can retrieve datastreams.json and connect to Schema Registry.
+//!
 use picky::hash::HashAlgorithm;
 use picky::key::PrivateKey;
 use picky::signature::SignatureAlgorithm;
 use picky::x509::csr::Csr;
 use picky::x509::name::{DirectoryName, NameAttr};
+use std::path::PathBuf;
 
 use reqwest::{Client, ClientBuilder, Identity};
 
@@ -11,12 +41,13 @@ use super::bootstrap::{Dn, DshCall, DshConfig};
 use crate::error::DshError;
 
 /// Hold all relevant certificates and keys to connect to DSH.
+///
+///
 #[derive(Debug, Clone)]
 pub struct Cert {
-    dsh_ca_certificate: String,
-    dsh_kafka_certificate: String,
-    private_key: String,
-    public_key: String,
+    dsh_ca_certificate_pem: String,
+    dsh_kafka_certificate_pem: String,
+    private_key: PrivateKey,
 }
 
 impl Cert {
@@ -28,17 +59,16 @@ impl Cert {
     ) -> Result<Self, DshError> {
         let private_key = PrivateKey::generate_rsa(4096)?;
         let csr = Self::generate_csr(&private_key, dn).await?;
-        let dsh_kafka_certificate = DshCall::CertificateSignRequest {
+        let dsh_kafka_certificate_pem = DshCall::CertificateSignRequest {
             config: dsh_config,
             csr: csr.to_pem()?,
         }
         .perform_call(client)
         .await?;
         Ok(Self {
-            dsh_ca_certificate: dsh_config.dsh_ca_certificate().to_string(),
-            dsh_kafka_certificate,
-            private_key: private_key.to_pem_str()?,
-            public_key: private_key.to_public_key()?.to_pem_str()?,
+            dsh_ca_certificate_pem: dsh_config.dsh_ca_certificate().to_string(),
+            dsh_kafka_certificate_pem,
+            private_key: private_key,
         })
     }
 
@@ -47,7 +77,7 @@ impl Cert {
     pub fn reqwest_client_config(&self) -> Result<ClientBuilder, DshError> {
         let pem_identity = Cert::create_identity(
             self.dsh_kafka_certificate_pem().as_bytes(),
-            self.private_key_pem().as_bytes(),
+            self.private_key_pem()?.as_bytes(),
         )?;
         let reqwest_cert =
             reqwest::tls::Certificate::from_pem(self.dsh_ca_certificate_pem().as_bytes())?;
@@ -58,23 +88,67 @@ impl Cert {
     }
 
     /// Get the root certificate as PEM string. Equivalent to ca.crt.
-    pub fn dsh_ca_certificate_pem(&self) -> String {
-        self.dsh_ca_certificate.clone()
+    pub fn dsh_ca_certificate_pem(&self) -> &str {
+        self.dsh_ca_certificate_pem.as_str()
     }
 
     /// Get the kafka certificate as PEM string. Equivalent to client.pem.
-    pub fn dsh_kafka_certificate_pem(&self) -> String {
-        self.dsh_kafka_certificate.clone()
+    pub fn dsh_kafka_certificate_pem(&self) -> &str {
+        self.dsh_kafka_certificate_pem.as_str()
+    }
+
+    /// Get the private key. This format is from the picky library.
+    ///
+    /// With this format we can convert it to other formats like PEM.
+    /// It allso is able to return the public key.
+    pub fn private_key(&self) -> &PrivateKey {
+        &self.private_key
+    }
+
+    /// Get the private key as PKCS8 and return bytes based on asn1 DER format.
+    pub fn private_key_pkcs8(&self) -> Result<Vec<u8>, DshError> {
+        Ok(self.private_key().to_pkcs8()?)
     }
 
     /// Get the private key as PEM string. Equivalent to client.key.
-    pub fn private_key_pem(&self) -> String {
-        self.private_key.clone()
+    pub fn private_key_pem(&self) -> Result<String, DshError> {
+        Ok(self.private_key().to_pem_str()?)
     }
 
     /// Get the public key as PEM string.
-    pub fn public_key_pem(&self) -> String {
-        self.public_key.clone()
+    pub fn public_key_pem(&self) -> Result<String, DshError> {
+        Ok(self.private_key().to_public_key()?.to_pem_str()?)
+    }
+
+    /// Get the public key as DER bytes.
+    pub fn public_key_der(&self) -> Result<Vec<u8>, DshError> {
+        Ok(self.private_key().to_public_key()?.to_der()?)
+    }
+
+    /// Create the ca.crt, client.pem, and client.key files in a desired directory.
+    ///
+    /// This method will create the directory if it does not exist.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use dsh_sdk::dsh::Properties;
+    /// use std::path::PathBuf;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
+    /// let dsh_properties = Properties::new().await?;
+    /// let directory = PathBuf::from("dir");
+    /// dsh_properties.certificates()?.to_files(&directory)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn to_files(&self, dir: &PathBuf) -> Result<(), DshError> {
+        std::fs::create_dir_all(dir)?;
+        std::fs::write(dir.join("ca.crt"), self.dsh_ca_certificate_pem())?;
+        std::fs::write(dir.join("client.pem"), self.dsh_kafka_certificate_pem())?;
+        std::fs::write(dir.join("client.key"), self.private_key_pkcs8()?)?;
+        Ok(())
     }
 
     /// Generate the certificate signing request.
@@ -105,13 +179,87 @@ impl Cert {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::OnceLock;
+
+    static TEST_CERTIFICATES: OnceLock<Cert> = OnceLock::new();
+
+    fn set_test_cert() -> Cert {
+        Cert{
+            dsh_ca_certificate_pem: "-----BEGIN CERTIFICATE-----\nMIIDYDCCAkigAwIBAgIUI--snip--\n-----END CERTIFICATE-----".to_string(),
+            dsh_kafka_certificate_pem: "-----BEGIN CERTIFICATE-----\nMIIDYDCCAkigAwIBAgIUI--snip--\n-----END CERTIFICATE-----".to_string(),
+            private_key: PrivateKey::generate_rsa(4096).unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_private_key_pem() {
+        let cert = TEST_CERTIFICATES.get_or_init(set_test_cert);
+        let pem = cert.private_key_pem().unwrap();
+        assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+        assert!(pem.ends_with("-----END PRIVATE KEY-----"));
+    }
+
+    #[test]
+    fn test_public_key_pem() {
+        let cert = TEST_CERTIFICATES.get_or_init(set_test_cert);
+        let pem = cert.public_key_pem().unwrap();
+        assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+        assert!(pem.ends_with("-----END PUBLIC KEY-----"));
+    }
+
+    #[test]
+    fn test_private_key_pkcs8() {
+        let cert = TEST_CERTIFICATES.get_or_init(set_test_cert);
+        let pkcs8 = cert.private_key_pkcs8().unwrap();
+        let picky_pks8 = PrivateKey::from_pkcs8(&pkcs8).unwrap();
+        assert_eq!(cert.private_key(), &picky_pks8);
+    }
+
+    #[test]
+    fn test_public_key_der() {
+        let cert = TEST_CERTIFICATES.get_or_init(set_test_cert);
+        let der = cert.public_key_der().unwrap();
+        let picky_der = cert
+            .private_key()
+            .to_public_key()
+            .unwrap()
+            .to_der()
+            .unwrap();
+        assert_eq!(der, picky_der);
+    }
+
+    #[test]
+    fn test_dsh_ca_certificate_pem() {
+        let cert = TEST_CERTIFICATES.get_or_init(set_test_cert);
+        let pem = cert.dsh_ca_certificate_pem();
+        assert!(pem.starts_with("-----BEGIN CERTIFICATE-----"));
+        assert!(pem.ends_with("-----END CERTIFICATE-----"));
+    }
+
+    #[test]
+    fn test_dsh_kafka_certificate_pem() {
+        let cert = TEST_CERTIFICATES.get_or_init(set_test_cert);
+        let pem = cert.dsh_kafka_certificate_pem();
+        assert!(pem.starts_with("-----BEGIN CERTIFICATE-----"));
+        assert!(pem.ends_with("-----END CERTIFICATE-----"));
+    }
+
+    #[test]
+    fn test_write_files() {
+        let cert = TEST_CERTIFICATES.get_or_init(set_test_cert);
+        let dir = PathBuf::from("test_files");
+        cert.to_files(&dir).unwrap();
+        let dir = "test_files";
+        assert!(std::path::Path::new(&format!("{}/ca.crt", dir)).exists());
+        assert!(std::path::Path::new(&format!("{}/client.pem", dir)).exists());
+        assert!(std::path::Path::new(&format!("{}/client.key", dir)).exists());
+    }
 
     #[tokio::test]
-    #[ignore] // This is ignored because it takes a long time to generate the private key in debug mode.
     async fn test_dsh_certificate_sign_request() {
-        let private_key = PrivateKey::generate_rsa(4096).unwrap();
+        let cert = TEST_CERTIFICATES.get_or_init(set_test_cert);
         let dn = Dn::parse_string("CN=Test CN,OU=Test OU,O=Test Org").unwrap();
-        let csr = Cert::generate_csr(&private_key, dn).await.unwrap();
+        let csr = Cert::generate_csr(&cert.private_key(), dn).await.unwrap();
         let (directory_name, pub_key) = csr.into_subject_infos();
         assert_eq!(
             directory_name.to_string(),
@@ -119,7 +267,7 @@ mod tests {
         );
         assert_eq!(
             pub_key.to_pem_str().unwrap(),
-            private_key.to_public_key().unwrap().to_pem_str().unwrap()
+            cert.public_key_pem().unwrap()
         );
     }
 }

--- a/src/dsh/certificates.rs
+++ b/src/dsh/certificates.rs
@@ -165,10 +165,7 @@ impl Cert {
     /// Generate the certificate signing request.
     ///
     /// Implementation via Picky library.
-    fn generate_csr(
-        private_key: &PrivateKey,
-        dn: Dn,
-    ) -> Result<Csr, picky::x509::csr::CsrError> {
+    fn generate_csr(private_key: &PrivateKey, dn: Dn) -> Result<Csr, picky::x509::csr::CsrError> {
         let mut subject = DirectoryName::new_common_name(dn.cn());
         subject.add_attr(NameAttr::OrganizationalUnitName, dn.ou());
         subject.add_attr(NameAttr::OrganizationName, dn.o());

--- a/src/dsh/certificates.rs
+++ b/src/dsh/certificates.rs
@@ -68,7 +68,7 @@ impl Cert {
         Ok(Self {
             dsh_ca_certificate_pem: dsh_config.dsh_ca_certificate().to_string(),
             dsh_kafka_certificate_pem,
-            private_key: private_key,
+            private_key,
         })
     }
 

--- a/src/dsh/certificates.rs
+++ b/src/dsh/certificates.rs
@@ -158,7 +158,7 @@ impl Cert {
         std::fs::create_dir_all(dir)?;
         Self::create_file(dir.join("ca.crt"), self.dsh_ca_certificate_pem())?;
         Self::create_file(dir.join("client.pem"), self.dsh_kafka_certificate_pem())?;
-        Self::create_file(dir.join("client.key"), self.private_key_pkcs8()?)?;
+        Self::create_file(dir.join("client.key"), self.private_key_pem()?)?;
         Ok(())
     }
 

--- a/src/dsh/datastream.rs
+++ b/src/dsh/datastream.rs
@@ -39,7 +39,6 @@ impl Datastream {
     pub fn get_group_id(&self, group_type: GroupType) -> Result<&str, DshError> {
         let group_id = match group_type {
             GroupType::Private(i) => self.private_consumer_groups.get(i),
-
             GroupType::Shared(i) => self.shared_consumer_groups.get(i),
         };
         info!("Kafka group id: {:?}", group_id);
@@ -108,6 +107,15 @@ impl Datastream {
     /// Reused in dsh_sdk::dsh::Properties
     pub fn schema_store(&self) -> &str {
         &self.schema_store
+    }
+
+    /// Write datastreams.json to a file in a directory
+    /// 
+    /// Directory
+    pub fn to_file(&self, directory: &std::path::PathBuf) -> Result<(), DshError>{
+        let json_string = serde_json::to_string_pretty(self)?;
+        std::fs::write(directory.join("datastreams.json"), json_string)?;
+        Ok(())
     }
 }
 
@@ -359,5 +367,12 @@ mod tests {
                 .write_access(),
             false
         );
+    }
+
+    #[test]
+    fn test_to_file() {
+        let test_path = std::path::PathBuf::from("test_files");
+        let result = datastream().to_file(&test_path);
+        assert!(result.is_ok())       
     }
 }

--- a/src/dsh/datastream.rs
+++ b/src/dsh/datastream.rs
@@ -110,9 +110,9 @@ impl Datastream {
     }
 
     /// Write datastreams.json to a file in a directory
-    /// 
+    ///
     /// Directory
-    pub fn to_file(&self, directory: &std::path::PathBuf) -> Result<(), DshError>{
+    pub fn to_file(&self, directory: &std::path::PathBuf) -> Result<(), DshError> {
         let json_string = serde_json::to_string_pretty(self)?;
         std::fs::write(directory.join("datastreams.json"), json_string)?;
         Ok(())
@@ -373,6 +373,6 @@ mod tests {
     fn test_to_file() {
         let test_path = std::path::PathBuf::from("test_files");
         let result = datastream().to_file(&test_path);
-        assert!(result.is_ok())       
+        assert!(result.is_ok())
     }
 }

--- a/src/dsh/datastream.rs
+++ b/src/dsh/datastream.rs
@@ -111,12 +111,12 @@ impl Datastream {
     ///
     /// # Example
     /// ```no_run
-    /// # use dsh_sdk::dsh::Datastream;
+    /// # use dsh_sdk::dsh::datastream::Datastream;
     /// # let datastream = Datastream::default();
     /// let path = std::path::PathBuf::from("/home/user");
-    /// datastream.to_file(&test_path).unwrap();
+    /// datastream.to_file(&path).unwrap();
     /// ```
-    pub fn to_file(&self, path: &std::path::PathBuf) -> Result<(), DshError> {
+    pub fn to_file(&self, path: &std::path::Path) -> Result<(), DshError> {
         let json_string = serde_json::to_string_pretty(self)?;
         std::fs::write(path.join("datastreams.json"), json_string)?;
         info!("File created ({})", path.display());

--- a/src/dsh/datastream.rs
+++ b/src/dsh/datastream.rs
@@ -119,7 +119,7 @@ impl Default for Datastream {
             private_consumer_groups: vec![],
             shared_consumer_groups: vec![],
             non_enveloped_streams: vec![],
-            schema_store: String::new(),
+            schema_store: String::from("http://localhost:8081/apis/ccompat/v7"),
         }
     }
 }

--- a/src/dsh/datastream.rs
+++ b/src/dsh/datastream.rs
@@ -21,7 +21,7 @@ pub struct Datastream {
 }
 
 impl Datastream {
-    /// Get the kafka brokers from the datastreams
+    /// Get the kafka brokers from the datastreams as a vector of strings
     pub fn get_brokers(&self) -> Vec<&str> {
         self.brokers.iter().map(|s| s.as_str()).collect()
     }
@@ -34,7 +34,7 @@ impl Datastream {
     /// Get the group id from the datastreams based on GroupType
     ///
     /// # Error
-    /// If the group type is not found in the datastreams
+    /// If the index is greater then amount of groups in the datastreams
     /// (index out of bounds)
     pub fn get_group_id(&self, group_type: GroupType) -> Result<&str, DshError> {
         let group_id = match group_type {
@@ -48,7 +48,7 @@ impl Datastream {
         }
     }
 
-    /// Get all available datastreams
+    /// Get all available datastreams (scratch topics, internal topics and stream topics)
     pub fn streams(&self) -> &HashMap<String, Stream> {
         &self.streams
     }
@@ -103,18 +103,23 @@ impl Datastream {
     }
 
     /// Get schema_store from datastreams info.
-    ///
-    /// Reused in dsh_sdk::dsh::Properties
     pub fn schema_store(&self) -> &str {
         &self.schema_store
     }
 
-    /// Write datastreams.json to a file in a directory
-    ///
-    /// Directory
-    pub fn to_file(&self, directory: &std::path::PathBuf) -> Result<(), DshError> {
+    /// Write datastreams.json in a directory
+    /// 
+    /// # Example
+    /// ```no_run
+    /// # use dsh_sdk::dsh::Datastream;
+    /// # let datastream = Datastream::default();
+    /// let path = std::path::PathBuf::from("/home/user");
+    /// datastream.to_file(&test_path).unwrap();
+    /// ```
+    pub fn to_file(&self, path: &std::path::PathBuf) -> Result<(), DshError> {
         let json_string = serde_json::to_string_pretty(self)?;
-        std::fs::write(directory.join("datastreams.json"), json_string)?;
+        std::fs::write(path.join("datastreams.json"), json_string)?;
+        info!("File created ({})", path.display());
         Ok(())
     }
 }

--- a/src/dsh/datastream.rs
+++ b/src/dsh/datastream.rs
@@ -108,7 +108,7 @@ impl Datastream {
     }
 
     /// Write datastreams.json in a directory
-    /// 
+    ///
     /// # Example
     /// ```no_run
     /// # use dsh_sdk::dsh::Datastream;

--- a/src/dsh/local.rs
+++ b/src/dsh/local.rs
@@ -3,7 +3,7 @@
 //! This module contains logic to load the local_datastreams.json file and parse it into a datastream struct inside the properties struct.
 //! This struct can be used to create a connection to your local Kafka cluster
 
-use log::{error, debug};
+use log::{debug, error};
 use std::fs::File;
 use std::io::Read;
 
@@ -47,7 +47,11 @@ impl Datastream {
         let mut file = match file_result {
             Ok(file) => file,
             Err(e) => {
-                error!("Error opening local_datastreams.json ({}): {}", path_buf.display(), e);
+                error!(
+                    "Error opening local_datastreams.json ({}): {}",
+                    path_buf.display(),
+                    e
+                );
                 return Err(DshError::IoErrorFile(FILE_NAME, e));
             }
         };

--- a/src/dsh/local.rs
+++ b/src/dsh/local.rs
@@ -3,7 +3,7 @@
 //! This module contains logic to load the local_datastreams.json file and parse it into a datastream struct inside the properties struct.
 //! This struct can be used to create a connection to your local Kafka cluster
 
-use log::error;
+use log::{error, debug};
 use std::fs::File;
 use std::io::Read;
 
@@ -23,13 +23,16 @@ impl Properties {
     /// - Error if local_datastreams.json is not present in the root of the project
     /// - Error if local_datastreams.json is not following the correct format
     pub(crate) fn new_local() -> Result<Self, DshError> {
+        debug!("Starting with local settings");
         let datastream = Datastream::load_local_datastreams()?;
-        let client_id = String::from("local");
+        let client_id = String::from("local_client_id");
         let tenant_name = String::from("local");
+        let task_id = String::from("local_task_id");
         let certificates = None;
         Ok(Self {
             client_id,
             tenant_name,
+            task_id,
             datastream,
             certificates,
         })
@@ -39,11 +42,12 @@ impl Properties {
 impl Datastream {
     fn load_local_datastreams() -> Result<Self, DshError> {
         let path_buf: std::path::PathBuf = std::env::current_dir().unwrap().join(FILE_NAME);
+        debug!("Reading local datastreams from {}", path_buf.display());
         let file_result = File::open(&path_buf);
         let mut file = match file_result {
             Ok(file) => file,
             Err(e) => {
-                error!("Error opening {}: {}", path_buf.display(), e);
+                error!("Error opening local_datastreams.json ({}): {}", path_buf.display(), e);
                 return Err(DshError::IoErrorFile(FILE_NAME, e));
             }
         };

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -22,7 +22,7 @@
 //!     Ok(())
 //! }
 //! ```
-use log::warn;
+use log::{info, warn};
 use std::env;
 use std::sync::OnceLock;
 
@@ -80,8 +80,8 @@ impl Properties {
     /// If running locally, it will try to load the local_datastreams.json file
     /// and crate the properties struct based on this file
     ///
-    /// # Error
-    /// If running locally and local_datastreams.json file is not present in the root of the project
+    /// # Panic
+    /// If initilization fails, it will panic per definition
     ///
     /// # local_datastreams.json
     /// local_datastreams.json should be placed in the root of the project
@@ -136,6 +136,7 @@ impl Properties {
         Ok(PROPERTIES.get_or_init(Self::init))
     }
 
+    /// Initialize the properties and bootstrap to DSH
     fn init() -> Self {
         #[cfg(not(feature = "local"))]
         let result = Self::new_dsh();
@@ -148,7 +149,13 @@ impl Properties {
                 Self::new_local()
             }
         };
-        result.expect("Initialization of DSH SDK failed!")
+        match result {
+            Ok(prop) => {
+                info!("DSH SDK initialized");
+                prop
+            }
+            Err(e) => panic!("Failed to initialize: {e}"),
+        }
     }
     /// Create a new Properties struct that contains all information and certificates.
     /// needed to connect to Kafka and DSH.

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let dsh_properties = Properties::get()?;
+//!     let dsh_properties = Properties::get();
 //!     
 //!     let consumer_config = dsh_properties.consumer_rdkafka_config()?;
 //!     let consumer: StreamConsumer = consumer_config.create()?;
@@ -48,7 +48,7 @@ static PROPERTIES: OnceLock<Properties> = OnceLock::new();
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let dsh_properties = Properties::get()?;
+///     let dsh_properties = Properties::get();
 ///     
 ///     let consumer_config = dsh_properties.consumer_rdkafka_config()?;
 ///     let consumer: StreamConsumer = consumer_config.create()?;
@@ -132,8 +132,8 @@ impl Properties {
     ///     "schema_store": "http://localhost:8081/apis/ccompat/v7"
     ///   }
     /// ```
-    pub fn get() -> Result<&'static Self, DshError> {
-        Ok(PROPERTIES.get_or_init(Self::init))
+    pub fn get() -> &'static Self {
+        PROPERTIES.get_or_init(Self::init)
     }
 
     /// Initialize the properties and bootstrap to DSH
@@ -154,7 +154,7 @@ impl Properties {
                 info!("DSH SDK initialized");
                 prop
             }
-            Err(e) => panic!("Failed to initialize: {e}"),
+            Err(e) => panic!("Could not bootstrap to DSH: {e}"),
         }
     }
     /// Create a new Properties struct that contains all information and certificates.
@@ -305,7 +305,7 @@ impl Properties {
     )]
     pub fn new_blocking() -> Result<Self, DshError> {
         let properties = Self::get();
-        properties.map(|p| p.clone())
+        Ok(properties.clone())
     }
 
     /// Get default RDKafka Consumer config to connect to Kafka on DSH.
@@ -323,7 +323,7 @@ impl Properties {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let dsh_properties = Properties::get()?;
+    ///     let dsh_properties = Properties::get();
     ///     let mut consumer_config = dsh_properties.consumer_rdkafka_config()?;
     ///     let consumer: StreamConsumer =  consumer_config.create().expect("Consumer creation failed");
     ///     Ok(())
@@ -393,7 +393,7 @@ impl Properties {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    ///     let dsh_properties = Properties::get()?;
+    ///     let dsh_properties = Properties::get();
     ///     let mut producer_config = dsh_properties.producer_rdkafka_config().expect("Producer config creation failed");
     ///     let producer: FutureProducer =  producer_config.create().expect("Producer creation failed");
     ///     Ok(())
@@ -448,7 +448,7 @@ impl Properties {
     /// # use reqwest::Client;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let dsh_properties = Properties::get()?;
+    ///     let dsh_properties = Properties::get();
     ///     let client = dsh_properties.reqwest_client_config()?.build()?;
     ///
     /// #    Ok(())
@@ -541,10 +541,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_if_set() {
+    async fn test_get_or_init() {
         let properties = Properties::get();
-        assert!(properties.is_ok());
-        let properties = properties.unwrap();
         assert_eq!(properties.client_id(), "local_client_id");
         assert_eq!(properties.task_id(), "local_task_id");
         assert_eq!(properties.tenant_name(), "local");

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -237,76 +237,6 @@ impl Properties {
         };
         result
     }
-    /// Create a new Properties on a blocking struct that contains all information and certificates.
-    /// needed to connect to Kafka and DSH.
-    ///
-    ///  - Contains a struct equal to datastreams.json
-    ///  - Metadata of running container/task
-    ///  - Certificates for Kafka and DSH
-    ///
-    /// If running locally, it will try to load the local_datastreams.json file
-    /// and crate the properties struct based on this file
-    ///
-    /// # Error
-    /// If running locally and local_datastreams.json file is not present in the root of the project
-    ///
-    /// # local_datastreams.json
-    /// local_datastreams.json should be placed in the root of the project
-    ///
-    /// Example of local_datastreams.json.
-    /// (important that read and write has correct topic names that are configured in your local kafka cluster)
-    ///
-    /// ```json
-    /// {
-    ///     "brokers": ["localhost:9092"],
-    ///     "streams": {
-    ///       "scratch.local": {
-    ///         "name": "scratch.local",
-    ///         "cluster": "/tt",
-    ///         "read": "scratch.local.local-tenant",
-    ///         "write": "scratch.local.local-tenant",
-    ///         "partitions": 3,
-    ///         "replication": 1,
-    ///         "partitioner": "default-partitioner",
-    ///         "partitioningDepth": 0,
-    ///         "canRetain": false
-    ///       },
-    ///       "stream.test": {
-    ///         "name": "scratch.dlq.local-tenant",
-    ///         "cluster": "/tt",
-    ///         "read": "scratch\\.dlq.\\[^.]*",
-    ///         "write": "scratch.dlq.local-tenant",
-    ///         "partitions": 1,
-    ///         "replication": 1,
-    ///         "partitioner": "default-partitioner",
-    ///         "partitioningDepth": 0,
-    ///         "canRetain": false
-    ///       }
-    ///     },
-    ///     "private_consumer_groups": [
-    ///       "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_1",
-    ///       "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_2",
-    ///       "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_3",
-    ///       "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_4"
-    ///     ],
-    ///     "shared_consumer_groups": [
-    ///       "local-app_1",
-    ///       "local-app_2",
-    ///       "local-app_3",
-    ///       "local-app_4"
-    ///     ],
-    ///     "non_enveloped_streams": [],
-    ///     "schema_store": "http://localhost:8081/apis/ccompat/v7"
-    ///   }
-    /// ```
-    #[deprecated(
-        since = "0.2.0",
-        note = "Use get_blocking() instead to avoid multiple bootstraps to DSH. Function to be removed in 0.3.0"
-    )]
-    pub fn new_blocking() -> Result<Self, DshError> {
-        let properties = Self::get();
-        Ok(properties.clone())
-    }
 
     /// Get default RDKafka Consumer config to connect to Kafka on DSH.
     /// If certificates are present, it will use SSL to connect to Kafka.
@@ -552,13 +482,6 @@ mod tests {
     #[tokio::test]
     async fn test_new() {
         let properties = Properties::new().await;
-        assert!(properties.is_ok());
-    }
-
-    #[allow(deprecated)]
-    #[test]
-    fn test_new_blocking() {
-        let properties = Properties::new_blocking();
         assert!(properties.is_ok());
     }
 

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -84,17 +84,17 @@ impl Properties {
     /// If initilization fails, it will panic
     ///
     /// # Required environment variables
-    /// The following environment variables are required to be set. If not set, it will default to local (or Panic! 
+    /// The following environment variables are required to be set. If not set, it will default to local (or Panic!
     /// when 'local' is disabled). When starting a container in DSH, these variable are automatically set.
-    /// 
+    ///
     /// - `MESOS_TASK_ID` - The task id of the running container
     /// - `MARATHON_APP_ID` - Includes the tenant name of the running container
     /// - `DSH_SECRET_TOKEN` - The secret token to authenticate to DSH
     /// - `DSH_CA_CERTIFICATE` - The CA certificate of DSH
-    /// 
+    ///
     /// ### Optional
     /// - `DSH_SECRET_TOKEN_PATH` - The path to the secret token file. (useful when running in system space)
-    /// 
+    ///
     /// # local_datastreams.json
     /// local_datastreams.json should be placed in the root of the project
     ///

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -22,16 +22,19 @@
 //!     Ok(())
 //! }
 //! ```
-use log::warn;
+use log::{debug, info, warn};
+use std::env;
+use std::sync::OnceLock;
 
 use crate::error::DshError;
-use std::env;
 
 pub mod bootstrap;
 pub mod certificates;
 pub mod datastream;
 #[cfg(feature = "local")]
 pub mod local;
+
+static PROPERTIES: OnceLock<Properties> = OnceLock::new();
 
 /// Kafka properties struct. Create new to initialize all related components to connect to the DSH kafka clusters
 ///  - Contains a struct similar to datastreams.json
@@ -57,12 +60,106 @@ pub mod local;
 #[derive(Debug, Clone)]
 pub struct Properties {
     client_id: String,
+    task_id: String,
     tenant_name: String,
     datastream: datastream::Datastream,
     certificates: Option<certificates::Cert>,
 }
 
 impl Properties {
+    /// Get the DSH Properties on a lazy way. If not already initialized, it will initialize the properties
+    /// and bootstrap to DSH.
+    ///
+    /// This struct contains all information and certificates.
+    /// needed to connect to Kafka and DSH.
+    ///
+    ///  - Contains a struct equal to datastreams.json
+    ///  - Metadata of running container/task
+    ///  - Certificates for Kafka and DSH
+    ///
+    /// If running locally, it will try to load the local_datastreams.json file
+    /// and crate the properties struct based on this file
+    ///
+    /// # Error
+    /// If running locally and local_datastreams.json file is not present in the root of the project
+    ///
+    /// # local_datastreams.json
+    /// local_datastreams.json should be placed in the root of the project
+    ///
+    /// Example of local_datastreams.json.
+    /// (important that read and write has correct topic names that are configured in your local kafka cluster)
+    ///
+    /// ```json
+    /// {
+    ///     "brokers": ["localhost:9092"],
+    ///     "streams": {
+    ///       "scratch.local": {
+    ///         "name": "scratch.local",
+    ///         "cluster": "/tt",
+    ///         "read": "scratch.local.local-tenant",
+    ///         "write": "scratch.local.local-tenant",
+    ///         "partitions": 3,
+    ///         "replication": 1,
+    ///         "partitioner": "default-partitioner",
+    ///         "partitioningDepth": 0,
+    ///         "canRetain": false
+    ///       },
+    ///       "stream.test": {
+    ///         "name": "scratch.dlq.local-tenant",
+    ///         "cluster": "/tt",
+    ///         "read": "scratch\\.dlq.\\[^.]*",
+    ///         "write": "scratch.dlq.local-tenant",
+    ///         "partitions": 1,
+    ///         "replication": 1,
+    ///         "partitioner": "default-partitioner",
+    ///         "partitioningDepth": 0,
+    ///         "canRetain": false
+    ///       }
+    ///     },
+    ///     "private_consumer_groups": [
+    ///       "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_1",
+    ///       "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_2",
+    ///       "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_3",
+    ///       "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_4"
+    ///     ],
+    ///     "shared_consumer_groups": [
+    ///       "local-app_1",
+    ///       "local-app_2",
+    ///       "local-app_3",
+    ///       "local-app_4"
+    ///     ],
+    ///     "non_enveloped_streams": [],
+    ///     "schema_store": "http://localhost:8081/apis/ccompat/v7"
+    ///   }
+    /// ```
+    pub async fn get() -> Result<&'static Self, DshError> {
+        //let properties = PROPERTIES.get_or_init(Self::init)
+        if let Some(properties) = PROPERTIES.get() {
+            debug!("Properties already initialized");
+            Ok(properties)
+        } else {
+            let properties: Properties = Self::init().await?;
+            match PROPERTIES.set(properties) {
+                Ok(_) => info!("Properties initialized"),
+                Err(_) => warn!("Properties already initialized by different thread. Ignoring."),
+            }
+            Ok(PROPERTIES.get().unwrap())
+        }
+    }
+    async fn init() -> Result<Self, DshError> {
+        #[cfg(not(feature = "local"))]
+        let result = Self::new_dsh().await;
+        #[cfg(feature = "local")]
+        let result = match Self::new_dsh().await {
+            Ok(b) => Ok(b),
+            Err(e) => {
+                warn!("App does not seem to be running on DSH, due to: {}", e);
+                warn!("Starting local properties instead");
+                Self::new_local()
+            }
+        };
+        result
+    }
     /// Create a new Properties struct that contains all information and certificates.
     /// needed to connect to Kafka and DSH.
     ///
@@ -82,7 +179,7 @@ impl Properties {
     /// Example of local_datastreams.json.
     /// (important that read and write has correct topic names that are configured in your local kafka cluster)
     ///
-    /// ```text
+    /// ```json
     /// {
     ///     "brokers": ["localhost:9092"],
     ///     "streams": {
@@ -125,6 +222,10 @@ impl Properties {
     ///     "schema_store": "http://localhost:8081/apis/ccompat/v7"
     ///   }
     /// ```
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use get() instead to avoid multiple bootstraps to DSH. Function to be removed in 0.3.0"
+    )]
     pub async fn new() -> Result<Self, DshError> {
         #[cfg(not(feature = "local"))]
         let result = Self::new_dsh().await;
@@ -139,7 +240,6 @@ impl Properties {
         };
         result
     }
-
     /// Create a new Properties on a blocking struct that contains all information and certificates.
     /// needed to connect to Kafka and DSH.
     ///
@@ -159,7 +259,7 @@ impl Properties {
     /// Example of local_datastreams.json.
     /// (important that read and write has correct topic names that are configured in your local kafka cluster)
     ///
-    /// ```text
+    /// ```json
     /// {
     ///     "brokers": ["localhost:9092"],
     ///     "streams": {
@@ -202,11 +302,16 @@ impl Properties {
     ///     "schema_store": "http://localhost:8081/apis/ccompat/v7"
     ///   }
     /// ```
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use get_blocking() instead to avoid multiple bootstraps to DSH. Function to be removed in 0.3.0"
+    )]
     pub fn new_blocking() -> Result<Self, DshError> {
-        tokio::runtime::Builder::new_current_thread()
+        let properties = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()?
-            .block_on(Self::new())
+            .block_on(Self::get());
+        properties.map(|p| p.clone())
     }
 
     /// Get default RDKafka Consumer config to connect to Kafka on DSH.
@@ -252,7 +357,7 @@ impl Properties {
     pub fn consumer_rdkafka_config(&self) -> Result<rdkafka::config::ClientConfig, DshError> {
         let mut config = rdkafka::config::ClientConfig::new();
         config
-            .set("bootstrap.servers", self.datastream().get_brokers())
+            .set("bootstrap.servers", self.datastream().get_brokers_string())
             .set(
                 "group.id",
                 self.datastream()
@@ -318,7 +423,7 @@ impl Properties {
     pub fn producer_rdkafka_config(&self) -> Result<rdkafka::config::ClientConfig, DshError> {
         let mut config = rdkafka::config::ClientConfig::new();
         config
-            .set("bootstrap.servers", self.datastream().get_brokers())
+            .set("bootstrap.servers", self.datastream().get_brokers_string())
             .set("client.id", self.client_id())
             .set_log_level(rdkafka::config::RDKafkaLogLevel::Info);
 
@@ -377,9 +482,14 @@ impl Properties {
         &self.client_id
     }
 
-    /// Get the tenant name.
+    /// Get the tenant name of running container.
     pub fn tenant_name(&self) -> &str {
         &self.tenant_name
+    }
+
+    /// Get the task id of running container.
+    pub fn task_id(&self) -> &str {
+        &self.task_id
     }
 
     /// Get the kafka properties provided by DSH (datastreams.json)
@@ -410,6 +520,16 @@ pub fn get_configured_topics() -> Result<Vec<String>, DshError> {
 mod tests {
     use super::*;
 
+    fn test_properties() -> Properties {
+        Properties {
+            client_id: "test_client_id".to_string(),
+            task_id: "test_task_id".to_string(),
+            tenant_name: "test".to_string(),
+            datastream: datastream::Datastream::default(),
+            certificates: None,
+        }
+    }
+
     #[test]
     fn test_get_configured_topics() {
         std::env::set_var("TOPICS", "topic1, topic2, topic3");
@@ -428,14 +548,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_if_set() {
+
+        PROPERTIES.set(test_properties()).unwrap();
+        let properties = Properties::get().await;
+        assert!(properties.is_ok());
+        let properties = properties.unwrap();
+        assert_eq!(properties.client_id(), "test_client_id");
+        assert_eq!(properties.task_id(), "test_task_id");
+        assert_eq!(properties.tenant_name(), "test");
+    }
+
+    #[allow(deprecated)]
+    #[tokio::test]
     async fn test_new() {
         let properties = Properties::new().await;
         assert!(properties.is_ok());
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_new_blocking() {
         let properties = Properties::new_blocking();
         assert!(properties.is_ok());
+    }
+
+    #[test]
+    fn test_consumer_rdkafka_config() {
+        let properties = &test_properties();
+        let config = properties.consumer_rdkafka_config();
+        assert!(config.is_ok());
+        let config = config.unwrap();
+        assert_eq!(
+            config.get("bootstrap.servers").unwrap(),
+            properties.datastream().get_brokers_string()
+        );
+        assert_eq!(
+            config.get("group.id").unwrap(),
+            properties
+                .datastream()
+                .get_group_id(datastream::GroupType::from_env())
+                .unwrap()
+        );
+        assert_eq!(config.get("client.id").unwrap(), properties.client_id());
+        assert_eq!(config.get("enable.auto.commit").unwrap(), "false");
+        assert_eq!(config.get("enable.auto.offset.store").unwrap(), "false");
+        assert_eq!(config.get("auto.offset.reset").unwrap(), "earliest");
+    }
+
+    #[tokio::test]
+    async fn test_producer_rdkafka_config() {
+        let properties = &test_properties();
+        let config = properties.producer_rdkafka_config();
+        assert!(config.is_ok());
+        let config = config.unwrap();
+        assert_eq!(
+            config.get("bootstrap.servers").unwrap(),
+            properties.datastream().get_brokers_string()
+        );
+        assert_eq!(config.get("client.id").unwrap(), properties.client_id());
+    }
+
+    #[test]
+    fn test_reqwest_client_config() {
+        let properties = &test_properties();
+        let config = properties.reqwest_client_config();
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_client_id() {
+        let properties = &test_properties();
+        assert_eq!(properties.client_id(), "local_client_id");
+    }
+
+    #[test]
+    fn test_tenant_name() {
+        let properties = &test_properties();
+        assert_eq!(properties.tenant_name(), "local");
+    }
+
+    #[test]
+    fn test_task_id() {
+        let properties = &test_properties();
+        assert_eq!(properties.task_id(), "local_task_id");
+    }
+
+    #[test]
+    fn test_schema_registry_host() {
+        let properties = &test_properties();
+        assert_eq!(
+            properties.schema_registry_host(),
+            "http://localhost:8081/apis/ccompat/v7"
+        );
     }
 }

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -315,7 +315,7 @@ impl Properties {
     /// | ssl.ca.pem          | CA certifacte                          | Root certificate, provided by DSH.                                                      |
     /// | log_level           | Info                                   | Log level of rdkafka                                                                    |
     #[cfg(any(feature = "rdkafka-ssl", feature = "rdkafka-ssl-vendored"))]
-    pub fn producer_rdkafka_config(&self) -> Result<rdkafka::config::ClientConfig, DshError>{
+    pub fn producer_rdkafka_config(&self) -> Result<rdkafka::config::ClientConfig, DshError> {
         let mut config = rdkafka::config::ClientConfig::new();
         config
             .set("bootstrap.servers", self.datastream().get_brokers())

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -81,8 +81,20 @@ impl Properties {
     /// and crate the properties struct based on this file
     ///
     /// # Panic
-    /// If initilization fails, it will panic per definition
+    /// If initilization fails, it will panic
     ///
+    /// # Required environment variables
+    /// The following environment variables are required to be set. If not set, it will default to local (or Panic! 
+    /// when 'local' is disabled). When starting a container in DSH, these variable are automatically set.
+    /// 
+    /// - `MESOS_TASK_ID` - The task id of the running container
+    /// - `MARATHON_APP_ID` - Includes the tenant name of the running container
+    /// - `DSH_SECRET_TOKEN` - The secret token to authenticate to DSH
+    /// - `DSH_CA_CERTIFICATE` - The CA certificate of DSH
+    /// 
+    /// ### Optional
+    /// - `DSH_SECRET_TOKEN_PATH` - The path to the secret token file. (useful when running in system space)
+    /// 
     /// # local_datastreams.json
     /// local_datastreams.json should be placed in the root of the project
     ///

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -151,7 +151,7 @@ impl Properties {
         };
         match result {
             Ok(prop) => {
-                info!("DSH SDK initialized");
+                info!("DSH SDK successfully initialized");
                 prop
             }
             Err(e) => panic!("Could not bootstrap to DSH: {e}"),

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -138,16 +138,17 @@ impl Properties {
     /// ```
     pub async fn new() -> Result<Self, DshError> {
         #[cfg(not(feature = "local"))]
-        Self::new_dsh().await;
+        let result = Self::new_dsh().await;
         #[cfg(feature = "local")]
-        match Self::new_dsh().await {
+        let result = match Self::new_dsh().await {
             Ok(b) => Ok(b),
             Err(e) => {
                 warn!("App does not seem to be running on DSH, due to: {}", e);
                 warn!("Starting with local settings");
                 Self::new_local()
             }
-        }
+        };
+        result
     }
 
     /// Create a new Properties on a blocking struct that contains all information and certificates.

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ pub enum DshError {
         status_code: reqwest::StatusCode,
         error_body: String,
     },
+    #[error("Certificates are not set")]
+    NoCertificates,
     #[error("Reqwest: {0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("IO error for file {0}: {1}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! It is also possible to get avaiable metadata or the certificates from the properties struct.
 //!
 //! ### Example:
-//! ```
+//! ```no_run
 //! # use dsh_sdk::dsh::Properties;
 //! # use dsh_sdk::rdkafka::consumer::stream_consumer::StreamConsumer;
 //! # #[tokio::main]
@@ -36,7 +36,7 @@
 //! // check for write access to topic
 //! let write_access = dsh_properties.datastream().get_stream("scratch.local.local-tenant").expect("Topic not found").write_access();
 //! // get the certificates, for example DSH_KAFKA_CERTIFICATE
-//! let dsh_kafka_certificate = dsh_properties.certificates().map(|certs| certs.dsh_kafka_certificate_pem());
+//! let dsh_kafka_certificate = dsh_properties.certificates()?.dsh_kafka_certificate_pem();
 //! #     Ok(())
 //! # }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 
 #[cfg(feature = "dlq")]
 pub mod dlq;
+#[cfg(feature = "bootstrap")]
 pub mod dsh;
 pub mod error;
 #[cfg(feature = "graceful_shutdown")]


### PR DESCRIPTION
This PR contains some breaking changes and will be published under version 0.2, see changelog for the breaking changes

This PR contains some extra functionality to run in system space and it also have extra low level API functions to interact with the certificates, required for the use case when running in system space.

Also, the dsh::Properties is now lazily available and will only initiate once. The bootstrap will run in a blocking mode, instead of async.