### PR TITLE
Fix deprecated API doc

### DIFF
--- a/src/dsh/bootstrap.rs
+++ b/src/dsh/bootstrap.rs
@@ -15,12 +15,9 @@
 //! ## Example
 //! ```
 //! use dsh_sdk::dsh::Properties;
-//! #
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let dsh_properties = Properties::new().await?;
-//! # Ok(())
-//! # }
+//!
+//! let dsh_properties = Properties::get();
+//! ```
 
 use log::{debug, info, warn};
 use reqwest::blocking::Client;

--- a/src/dsh/certificates.rs
+++ b/src/dsh/certificates.rs
@@ -13,10 +13,9 @@
 //! ```no_run
 //! use dsh_sdk::dsh::Properties;
 //! use std::path::PathBuf;
-//! #
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-//! let dsh_properties = Properties::new().await?;
+//! 
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let dsh_properties = Properties::get();
 //! let directory = PathBuf::from("dir");
 //! dsh_properties.certificates()?.to_files(&directory)?;
 //! # Ok(())
@@ -145,10 +144,9 @@ impl Cert {
     /// ```no_run
     /// use dsh_sdk::dsh::Properties;
     /// use std::path::PathBuf;
-    /// #
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    /// let dsh_properties = Properties::new().await?;
+    /// 
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let dsh_properties = Properties::get();
     /// let directory = PathBuf::from("dir");
     /// dsh_properties.certificates()?.to_files(&directory)?;
     /// # Ok(())

--- a/src/dsh/certificates.rs
+++ b/src/dsh/certificates.rs
@@ -13,7 +13,7 @@
 //! ```no_run
 //! use dsh_sdk::dsh::Properties;
 //! use std::path::PathBuf;
-//! 
+//!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let dsh_properties = Properties::get();
 //! let directory = PathBuf::from("dir");
@@ -144,7 +144,7 @@ impl Cert {
     /// ```no_run
     /// use dsh_sdk::dsh::Properties;
     /// use std::path::PathBuf;
-    /// 
+    ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let dsh_properties = Properties::get();
     /// let directory = PathBuf::from("dir");

--- a/src/dsh/mod.rs
+++ b/src/dsh/mod.rs
@@ -12,15 +12,14 @@
 //! use dsh_sdk::dsh::Properties;
 //! use dsh_sdk::rdkafka::consumer::{Consumer, StreamConsumer};
 //!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let dsh_properties = Properties::get();
-//!     
-//!     let consumer_config = dsh_properties.consumer_rdkafka_config()?;
-//!     let consumer: StreamConsumer = consumer_config.create()?;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let dsh_properties = Properties::get();
+//! let consumer_config = dsh_properties.consumer_rdkafka_config()?;
+//! let consumer: StreamConsumer = consumer_config.create()?;
 //!
-//!     Ok(())
-//! }
+//! # Ok(())
+//! # }
 //! ```
 use log::{info, warn};
 use std::env;
@@ -482,8 +481,8 @@ mod tests {
         assert!(topics.is_err());
     }
 
-    #[tokio::test]
-    async fn test_get_or_init() {
+    #[test]
+    fn test_get_or_init() {
         let properties = Properties::get();
         assert_eq!(properties.client_id(), "local_client_id");
         assert_eq!(properties.task_id(), "local_task_id");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! ```
 //! use dsh_sdk::dsh::Properties;
 //! use dsh_sdk::rdkafka::consumer::stream_consumer::StreamConsumer;
-//! 
+//!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>>{
 //! let dsh_properties = Properties::get();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,10 @@
 //! ```
 //! use dsh_sdk::dsh::Properties;
 //! use dsh_sdk::rdkafka::consumer::stream_consumer::StreamConsumer;
-//!
+//! 
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-//! let dsh_properties = Properties::new().await?;
+//! let dsh_properties = Properties::get();
 //! let consumer: StreamConsumer = dsh_properties.consumer_rdkafka_config()?.create()?;
 //! # Ok(())
 //! # }
@@ -30,9 +30,9 @@
 //! ```no_run
 //! # use dsh_sdk::dsh::Properties;
 //! # use dsh_sdk::rdkafka::consumer::stream_consumer::StreamConsumer;
-//! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-//! #    let dsh_properties = Properties::new().await?;
+
+//! # fn main() -> Result<(), Box<dyn std::error::Error>>{
+//! #    let dsh_properties = Properties::get();
 //! // check for write access to topic
 //! let write_access = dsh_properties.datastream().get_stream("scratch.local.local-tenant").expect("Topic not found").write_access();
 //! // get the certificates, for example DSH_KAFKA_CERTIFICATE


### PR DESCRIPTION
Fix deprecated API doc

Some places still used the Properties::new() in example instead of Properties::get() 