### PR TITLE
rename platform methods to meaningful names

### DIFF
--- a/dsh_sdk/CHANGELOG.md
+++ b/dsh_sdk/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bootstrap to DSH
   - Read certificates from PKI_CONFIG_DIR
   - Add support reading private key in DER format when reading from PKI_CONFIG_DIR
+- Implement `TryFrom<&Str>` and `RryFrom<String>` for `dsh_sdk::Platform`
 
 ### Changed
 - **Breaking change:** `DshError` is now split into error enums per feature flag to untangle mess
@@ -20,18 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking change:** `dsh_sdk::Dsh::reqwest_client_config` now returns `reqwest::ClientConfig` instead of `Result<reqwest::ClientConfig>` 
 - **Breaking change:** `dsh_sdk::Dsh::reqwest_blocking_client_config` now returns `reqwest::ClientConfig` instead of `Result<reqwest::ClientConfig>` 
 - **Breaking change:** `dsh_sdk::utils::Dlq` does not require `Dsh`/`Properties` as argument anymore
-- Deprecated `dsh_sdk::dsh::properties` module
-- Moved `dsh_sdk::rest_api_token_fetcher` to `dsh_sdk::management_api::token_fetcher` and renamed `RestApiTokenFetcher` to `ManagementApiTokenFetcher`
-- `dsh_sdk::error::DshRestTokenError` renamed to `dsh_sdk::management_api::error::ManagementApiTokenError`
+- **Breaking change:** `dsh_sdk::utils::Dlq::new` is removed and replaced with `dsh_sdk::utils::Dlq::start` which starts the DLQ and returns a channel to send dlq messages
+- **Breaking change:** Deprecated `dsh_sdk::dsh::properties` module
+- **Breaking change:** Moved `dsh_sdk::rest_api_token_fetcher` to `dsh_sdk::management_api::token_fetcher` and renamed `RestApiTokenFetcher` to `ManagementApiTokenFetcher`
+- **Breaking change:** `dsh_sdk::error::DshRestTokenError` renamed to `dsh_sdk::management_api::error::ManagementApiTokenError`
   - **NOTE** Cargo.toml feature flag `rest-token-fetcher` renamed to`management-api-token-fetcher` 
 - Moved `dsh_sdk::dsh::datastream` to `dsh_sdk::datastream`
 - Moved `dsh_sdk::dsh::certificates` to `dsh_sdk::certificates`
   - Private module `dsh_sdk::dsh::bootstrap` and `dsh_sdk::dsh::pki_config_dir` are now part of `certificates` module
-- Moved `dsh_sdk::mqtt_token_fetcher` to `dsh_sdk::protocol_adapters::token_fetcher` and renamed to `ProtocolTokenFetcher`
-  - Cargo.toml feature flag `mqtt-token-fetcher`  renamed to `protocol-token-fetcher`
+- **Breaking change:** Moved `dsh_sdk::mqtt_token_fetcher` to `dsh_sdk::protocol_adapters::token_fetcher` and renamed to `ProtocolTokenFetcher`
+  -  **NOTE** Cargo.toml feature flag `mqtt-token-fetcher`  renamed to `protocol-token-fetcher`
+- **Breaking change:** Renamed  `dsh_sdk::Platform` methods to more meaningful names
 - **Breaking change:** Moved `dsh_sdk::dlq` to `dsh_sdk::utils::dlq` 
 - **Breaking change:** Moved `dsh_sdk::graceful_shutdown` to `dsh_sdk::utils::graceful_shutdown`
 - **Breaking change:** Moved `dsh_sdk::metrics` to `dsh_sdk::utils::metrics`
+- **Breaking change:** `dsh_sdk::utils::metrics::start_metrics_server` requires `fn() -> String` which gathers and encodes metrics
 
 ### Removed
 - Removed `dsh_sdk::rdkafka` public re-export, import `rdkafka` directly

--- a/dsh_sdk/examples/management_api_token_fetcher.rs
+++ b/dsh_sdk/examples/management_api_token_fetcher.rs
@@ -15,7 +15,7 @@ async fn main() {
     let client_secret =
         env::var("CLIENT_SECRET").expect("CLIENT_SECRET must be set as environment variable");
     let tenant = env::var("TENANT").expect("TENANT must be set as environment variable");
-    let client = Client::new(platform.endpoint_rest_api());
+    let client = Client::new(platform.endpoint_management_api());
     let tf = ManagementApiTokenFetcherBuilder::new(platform)
         .tenant_name(tenant.clone())
         .client_secret(client_secret)

--- a/dsh_sdk/src/utils/platform.rs
+++ b/dsh_sdk/src/utils/platform.rs
@@ -61,7 +61,7 @@ impl Platform {
     /// let client_id = platform.rest_client_id("my-tenant");
     /// assert_eq!(client_id, "robot:dev-lz-dsh:my-tenant");
     /// ```
-    pub fn rest_client_id<T>(&self, tenant: T) -> String
+    pub fn rest_client_id(&self, tenant: impl AsRef<str>) -> String
     where
         T: AsRef<str>,
     {
@@ -82,7 +82,7 @@ impl Platform {
     /// let client_id = platform.rest_client_id("my-tenant");
     /// assert_eq!(client_id, "robot:dev-lz-dsh:my-tenant");
     /// ```
-    pub fn management_api_client_id<T>(&self, tenant: T) -> String
+    pub fn management_api_client_id(&self, tenant: impl AsRef<str>) -> String
     where
         T: AsRef<str>,
     {

--- a/dsh_sdk/src/utils/platform.rs
+++ b/dsh_sdk/src/utils/platform.rs
@@ -61,10 +61,7 @@ impl Platform {
     /// let client_id = platform.rest_client_id("my-tenant");
     /// assert_eq!(client_id, "robot:dev-lz-dsh:my-tenant");
     /// ```
-    pub fn rest_client_id(&self, tenant: impl AsRef<str>) -> String
-    where
-        T: AsRef<str>,
-    {
+    pub fn rest_client_id(&self, tenant: impl AsRef<str>) -> String {
         self.management_api_client_id(tenant)
     }
 
@@ -82,10 +79,7 @@ impl Platform {
     /// let client_id = platform.rest_client_id("my-tenant");
     /// assert_eq!(client_id, "robot:dev-lz-dsh:my-tenant");
     /// ```
-    pub fn management_api_client_id(&self, tenant: impl AsRef<str>) -> String
-    where
-        T: AsRef<str>,
-    {
+    pub fn management_api_client_id(&self, tenant: impl AsRef<str>) -> String {
         format!("robot:{}:{}", self.realm(), tenant.as_ref())
     }
 


### PR DESCRIPTION
Some methods still refer to "Rest API" instead of "Management API"