### PR TITLE
Add custom deserializer to append ^ when needed for proper rfkafka regex support

### DIFF
--- a/dsh_sdk/CHANGELOG.md
+++ b/dsh_sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Changed
+- `read_access()` and `write_access()` are deprecated in favor of `is_readable()` and `is_writable()`, which provide clearer semantics.
 ### Fixed
 - Return librdkafka compatible anchored read pattern in case of regex wildard
 - verify_list_of_topics now properly checks write topics including tenant name

--- a/dsh_sdk/CHANGELOG.md
+++ b/dsh_sdk/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- Return librdkafka compatible anchored read pattern in case of regex wildard
+- verify_list_of_topics now properly checks write topics including tenant name
+
 ## [0.8.1] - 2026-4-08
 ### Added
 - HTTP Protocol Adapter client

--- a/dsh_sdk/local_datastreams.json
+++ b/dsh_sdk/local_datastreams.json
@@ -1,52 +1,65 @@
 {
-    "brokers": ["localhost:9092"],
-    "streams": {
-      "scratch.local": {
-        "name": "scratch.local",
-        "cluster": "/tt",
-        "read": "scratch.local.local-tenant",
-        "write": "scratch.local.local-tenant",
-        "partitions": 3,
-        "replication": 1,
-        "partitioner": "default-partitioner",
-        "partitioningDepth": 0,
-        "canRetain": false
-      },
-      "scratch.dlq-dead": {
-        "name": "scratch.dlq-dead.local-tenant",
-        "cluster": "/tt",
-        "read": "scratch\\.dlq-dead.\\[^.]*",
-        "write": "scratch.dlq-dead.local-tenant",
-        "partitions": 1,
-        "replication": 1,
-        "partitioner": "default-partitioner",
-        "partitioningDepth": 0,
-        "canRetain": false
-      }      ,
-      "scratch.dlq-retry": {
-        "name": "scratch.dlq-retry.local-tenant",
-        "cluster": "/tt",
-        "read": "scratch\\.dlq-retry.\\[^.]*",
-        "write": "scratch.dlq-retry.local-tenant",
-        "partitions": 1,
-        "replication": 1,
-        "partitioner": "default-partitioner",
-        "partitioningDepth": 0,
-        "canRetain": false
-      }
+  "brokers": [
+    "localhost:9092"
+  ],
+  "streams": {
+    "scratch.local": {
+      "name": "scratch.local",
+      "cluster": "/tt",
+      "read": "scratch.local.local-tenant",
+      "write": "scratch.local.local-tenant",
+      "partitions": 3,
+      "replication": 1,
+      "partitioner": "default-partitioner",
+      "partitioningDepth": 0,
+      "canRetain": false
     },
-    "private_consumer_groups": [
-      "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_1",
-      "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_2",
-      "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_3",
-      "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_4"
-    ],
-    "shared_consumer_groups": [
-      "local-app_1",
-      "local-app_2",
-      "local-app_3",
-      "local-app_4"
-    ],
-    "non_enveloped_streams": [],
-    "schema_store": "http://localhost:8081/apis/ccompat/v7"
-  }
+    "scratch.dlq-dead": {
+      "name": "scratch.dlq-dead.local-tenant",
+      "cluster": "/tt",
+      "read": "scratch\\.dlq-dead.\\[^.]*",
+      "write": "scratch.dlq-dead.local-tenant",
+      "partitions": 1,
+      "replication": 1,
+      "partitioner": "default-partitioner",
+      "partitioningDepth": 0,
+      "canRetain": false
+    },
+    "scratch.dlq-retry": {
+      "name": "scratch.dlq-retry.local-tenant",
+      "cluster": "/tt",
+      "read": "scratch\\.dlq-retry.\\[^.]*",
+      "write": "scratch.dlq-retry.local-tenant",
+      "partitions": 1,
+      "replication": 1,
+      "partitioner": "default-partitioner",
+      "partitioningDepth": 0,
+      "canRetain": false
+    },
+    "stream.example": {
+      "name": "stream.example",
+      "cluster": "/tt",
+      "read": "stream\\.example\\.[^.]*",
+      "write": "",
+      "partitions": 6,
+      "replication": 3,
+      "partitioner": "topic-level-partitioner",
+      "partitioningDepth": 3,
+      "canRetain": false
+    }
+  },
+  "private_consumer_groups": [
+    "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_1",
+    "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_2",
+    "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_3",
+    "local-app.7e93a513-6556-11eb-841e-f6ab8576620c_4"
+  ],
+  "shared_consumer_groups": [
+    "local-app_1",
+    "local-app_2",
+    "local-app_3",
+    "local-app_4"
+  ],
+  "non_enveloped_streams": [],
+  "schema_store": "http://localhost:8081/apis/ccompat/v7"
+}

--- a/dsh_sdk/src/datastream/mod.rs
+++ b/dsh_sdk/src/datastream/mod.rs
@@ -67,8 +67,8 @@ const FILE_NAME: &str = "local_datastreams.json";
 /// - A Schema Store URL  
 ///
 /// ## Example
-/// How to get a [Stream] and subscribe to it rdkafka:
-/// ```no_run
+/// How to get a [`Stream`] and subscribe to it using rdkafka:
+/// ```
 /// use rdkafka::config::ClientConfig;
 /// use rdkafka::consumer::{Consumer, StreamConsumer};
 /// use dsh_sdk::DshKafkaConfig;
@@ -84,7 +84,11 @@ const FILE_NAME: &str = "local_datastreams.json";
 ///     .set_dsh_consumer_config()
 ///     .create()?;
 ///
-/// consumer.subscribe(&[stream.read()])?;
+/// let pattern = stream
+///     .read_pattern()
+///     .expect("should have read access to stream");
+///
+/// consumer.subscribe(&[pattern])?;
 /// # Ok(())
 /// # }
 /// ```
@@ -369,7 +373,7 @@ pub struct Stream {
     can_retain: bool,
 }
 
-/// Custom deserialization function for the `read` field of `Stream`.
+/// Custom deserialization function for the `read` field of [`Stream`].
 ///
 /// This makes it librdkafka-compatible by prepending a `^` anchor to any pattern that ends with `*` but doesn't already start with `^`.
 /// Librdkafka requires regex patterns to be anchored, and this ensures that common wildcard patterns are correctly interpreted without requiring users to manually add the anchor in `datastreams.json`.

--- a/dsh_sdk/src/datastream/mod.rs
+++ b/dsh_sdk/src/datastream/mod.rs
@@ -401,9 +401,10 @@ impl Stream {
         &self.cluster
     }
 
-    /// Returns the read pattern (regex or exact topic name).
+    /// Returns the read pattern (regex or exact topic name) or an empty string when no read access is granted.
     ///
-    /// Use [`Self::read_access`] or [`Self::read_pattern`] to confirm read permissions.
+    /// ## Recommended Usage
+    /// Use [`Self::read_pattern`] to get a `Result` based on access.
     ///
     /// ## Example
     /// How to use the read pattern in rdkafka to consume from.
@@ -423,7 +424,7 @@ impl Stream {
     ///     .set_dsh_consumer_config()
     ///     .create()?;
     ///
-    /// consumer.subscribe(&[stream.read()])?;
+    /// consumer.subscribe(&[stream.read_pattern()?])?;
     /// # Ok(())
     /// # }
     /// ```
@@ -431,9 +432,9 @@ impl Stream {
         &self.read
     }
 
-    /// Returns the write pattern (regex or exact topic name).
+    /// Returns the write pattern (regex or exact topic name) or an empty string when no write access is granted.
     ///
-    /// Use [`Self::write_access`] or [`Self::write_pattern`] to confirm write permissions.
+    /// Use [`Self::write_pattern`] to get a `Result` based on access.
     pub fn write(&self) -> &str {
         &self.write
     }
@@ -476,22 +477,62 @@ impl Stream {
         self.can_retain
     }
 
+    #[deprecated(
+        since = "0.8.1",
+        note = "This method is deprecated in favor of `is_readable()` and `is_writable()`, which provide clearer semantics."
+    )]
     /// Checks if the stream has a `read` pattern configured.
     pub fn read_access(&self) -> bool {
+        self.is_readable()
+    }
+
+    #[deprecated(
+        since = "0.8.1",
+        note = "This method is deprecated in favor of `is_readable()` and `is_writable()`, which provide clearer semantics."
+    )]
+    /// Checks if the stream has a `write` pattern configured.
+    pub fn write_access(&self) -> bool {
+        self.is_writable()
+    }
+
+    /// Checks if the stream has a `read` permission.
+    pub fn is_readable(&self) -> bool {
         !self.read.is_empty()
     }
 
-    /// Checks if the stream has a `write` pattern configured.
-    pub fn write_access(&self) -> bool {
+    /// Checks if the stream has a `write` permission.
+    pub fn is_writable(&self) -> bool {
         !self.write.is_empty()
     }
 
     /// Returns the read pattern, or errors if the stream has no read access.
     ///
-    /// # Errors
+    /// ## Errors
     /// Returns [`DatastreamError::TopicPermissionsError`] if the stream has no read pattern set.
+    ///
+    /// ## Example
+    /// How to use this method to check for read access before consuming.
+    /// ```no_run
+    /// use rdkafka::config::ClientConfig;
+    /// use rdkafka::consumer::{Consumer, StreamConsumer};
+    /// use dsh_sdk::DshKafkaConfig;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let datastreams = dsh_sdk::Dsh::get().datastream();
+    /// let stream = datastreams
+    ///     .get_stream("stream.example-topic")
+    ///     .expect("stream.example-topic should be available to your tenant");
+    ///
+    /// let consumer: StreamConsumer = ClientConfig::new()
+    ///     .set_dsh_consumer_config()
+    ///     .create()?;
+    ///
+    /// consumer.subscribe(&[stream.read_pattern()?])?;
+    /// # Ok(())
+    /// # }
     pub fn read_pattern(&self) -> Result<&str, DatastreamError> {
-        if self.read_access() {
+        if self.is_readable() {
             Ok(&self.read)
         } else {
             Err(DatastreamError::TopicPermissionsError(
@@ -506,7 +547,7 @@ impl Stream {
     /// # Errors
     /// Returns [`DatastreamError::TopicPermissionsError`] if the stream has no write pattern set.
     pub fn write_pattern(&self) -> Result<&str, DatastreamError> {
-        if self.write_access() {
+        if self.is_writable() {
             Ok(&self.write)
         } else {
             Err(DatastreamError::TopicPermissionsError(
@@ -905,14 +946,14 @@ mod tests {
             datastream()
                 .get_stream("scratch.test.test-tenant")
                 .unwrap()
-                .read_access(),
+                .is_readable(),
             true
         );
         assert_eq!(
             datastream()
                 .get_stream("stream.test.test-tenant")
                 .unwrap()
-                .read_access(),
+                .is_readable(),
             true
         );
     }
@@ -923,14 +964,14 @@ mod tests {
             datastream()
                 .get_stream("scratch.test.test-tenant")
                 .unwrap()
-                .write_access(),
+                .is_writable(),
             true
         );
         assert_eq!(
             datastream()
                 .get_stream("stream.test.test-tenant")
                 .unwrap()
-                .write_access(),
+                .is_writable(),
             false
         );
     }

--- a/dsh_sdk/src/datastream/mod.rs
+++ b/dsh_sdk/src/datastream/mod.rs
@@ -77,7 +77,7 @@ const FILE_NAME: &str = "local_datastreams.json";
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let datastreams = dsh_sdk::Dsh::get().datastream();
 /// let stream = datastreams
-///     .get_stream("stream.example-topic")
+///     .get_stream("stream.example")
 ///     .expect("stream.example-topic should be available to your tenant");
 ///
 /// let consumer: StreamConsumer = ClientConfig::new()

--- a/dsh_sdk/src/datastream/mod.rs
+++ b/dsh_sdk/src/datastream/mod.rs
@@ -38,7 +38,7 @@ use std::fs::File;
 use std::io::Read;
 
 use log::{debug, error, info};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "kafka")]
 use crate::protocol_adapters::kafka_protocol::{
@@ -66,16 +66,27 @@ const FILE_NAME: &str = "local_datastreams.json";
 /// - Mapping of topic names to [`Stream`] configurations  
 /// - A Schema Store URL  
 ///
-/// # Example
-/// ```
-/// use dsh_sdk::Dsh;
+/// ## Example
+/// How to get a [Stream] and subscribe to it rdkafka:
+/// ```no_run
+/// use rdkafka::config::ClientConfig;
+/// use rdkafka::consumer::{Consumer, StreamConsumer};
+/// use dsh_sdk::DshKafkaConfig;
 ///
-/// let dsh = Dsh::get();
-/// let datastream = dsh.datastream(); // Typically loaded at init
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let datastreams = dsh_sdk::Dsh::get().datastream();
+/// let stream = datastreams
+///     .get_stream("stream.example-topic")
+///     .expect("stream.example-topic should be available to your tenant");
 ///
-/// let brokers = datastream.get_brokers();
-/// let streams = datastream.streams();
-/// let schema_store_url = datastream.schema_store();
+/// let consumer: StreamConsumer = ClientConfig::new()
+///     .set_dsh_consumer_config()
+///     .create()?;
+///
+/// consumer.subscribe(&[stream.read()])?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Datastream {
@@ -146,27 +157,25 @@ impl Datastream {
             .map(|datastream| match access {
                 ReadWriteAccess::Read => datastream
                     .read
+                    .trim_start_matches('^')
                     .split('.')
                     .take(2)
                     .collect::<Vec<&str>>()
                     .join(".")
                     .replace('\\', ""),
-                ReadWriteAccess::Write => datastream
-                    .write
-                    .split('.')
-                    .take(2)
-                    .collect::<Vec<&str>>()
-                    .join(".")
-                    .replace('\\', ""),
+                ReadWriteAccess::Write => datastream.write.clone(),
             })
             .collect::<Vec<String>>();
         for topic in topics {
-            let topic_name = topic
-                .to_string()
-                .split('.')
-                .take(2)
-                .collect::<Vec<&str>>()
-                .join(".");
+            let topic_name = match access {
+                ReadWriteAccess::Read => topic
+                    .to_string()
+                    .split('.')
+                    .take(2)
+                    .collect::<Vec<&str>>()
+                    .join("."),
+                ReadWriteAccess::Write => topic.to_string(),
+            };
             if !read_topics.contains(&topic_name) {
                 return Err(DatastreamError::NotFoundTopicError(topic.to_string()));
             }
@@ -350,6 +359,7 @@ impl Default for Datastream {
 pub struct Stream {
     name: String,
     cluster: String,
+    #[serde(deserialize_with = "deserialize_read_pattern")]
     read: String,
     write: String,
     partitions: usize,
@@ -357,6 +367,23 @@ pub struct Stream {
     partitioner: PartitionerType,
     partitioning_depth: usize,
     can_retain: bool,
+}
+
+/// Custom deserialization function for the `read` field of `Stream`.
+///
+/// This makes it librdkafka-compatible by prepending a `^` anchor to any pattern that ends with `*` but doesn't already start with `^`.
+/// Librdkafka requires regex patterns to be anchored, and this ensures that common wildcard patterns are correctly interpreted without requiring users to manually add the anchor in `datastreams.json`.
+fn deserialize_read_pattern<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let read = String::deserialize(deserializer)?;
+
+    if read.ends_with('*') && !read.starts_with('^') {
+        Ok(format!("^{read}"))
+    } else {
+        Ok(read)
+    }
 }
 
 impl Stream {
@@ -373,6 +400,29 @@ impl Stream {
     /// Returns the read pattern (regex or exact topic name).
     ///
     /// Use [`Self::read_access`] or [`Self::read_pattern`] to confirm read permissions.
+    ///
+    /// ## Example
+    /// How to use the read pattern in rdkafka to consume from.
+    /// ```no_run
+    /// use rdkafka::config::ClientConfig;
+    /// use rdkafka::consumer::{Consumer, StreamConsumer};
+    /// use dsh_sdk::DshKafkaConfig;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let datastreams = dsh_sdk::Dsh::get().datastream();
+    /// let stream = datastreams
+    ///     .get_stream("stream.example-topic")
+    ///     .expect("stream.example-topic should be available to your tenant");
+    ///
+    /// let consumer: StreamConsumer = ClientConfig::new()
+    ///     .set_dsh_consumer_config()
+    ///     .create()?;
+    ///
+    /// consumer.subscribe(&[stream.read()])?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn read(&self) -> &str {
         &self.read
     }
@@ -637,7 +687,70 @@ mod tests {
         let stream = datastream.streams().get("scratch.test").unwrap();
         assert_eq!(stream.read(), "scratch.test.test-tenant");
         let stream = datastream.streams().get("stream.test").unwrap();
-        assert_eq!(stream.read(), "stream\\.test\\.[^.]*");
+        assert_eq!(stream.read(), "^stream\\.test\\.[^.]*");
+    }
+
+    #[test]
+    fn test_read_deserialization_prepends_anchor_for_wildcard_suffix() {
+        let stream: Stream = serde_json::from_str(
+            r#"{
+                "name": "stream.reference-implementation",
+                "cluster": "/tt",
+                "read": "stream\\.reference-implementation\\.[^.]*",
+                "write": "stream.reference-implementation.tenant",
+                "partitions": 1,
+                "replication": 1,
+                "partitioner": "default-partitioner",
+                "partitioningDepth": 0,
+                "canRetain": false
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(stream.read(), "^stream\\.reference-implementation\\.[^.]*");
+        assert_eq!(stream.write(), "stream.reference-implementation.tenant");
+    }
+
+    #[test]
+    fn test_read_deserialization_already_anchored_for_wildcard_suffix() {
+        let stream: Stream = serde_json::from_str(
+            r#"{
+                "name": "stream.reference-implementation",
+                "cluster": "/tt",
+                "read": "^stream\\.reference-implementation\\.[^.]*",
+                "write": "stream.reference-implementation.tenant",
+                "partitions": 1,
+                "replication": 1,
+                "partitioner": "default-partitioner",
+                "partitioningDepth": 0,
+                "canRetain": false
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(stream.read(), "^stream\\.reference-implementation\\.[^.]*");
+        assert_eq!(stream.write(), "stream.reference-implementation.tenant");
+    }
+
+    #[test]
+    fn test_read_deserialization_prepends() {
+        let stream: Stream = serde_json::from_str(
+            r#"{
+                "name": "scratch.reference-implementation",
+                "cluster": "/tt",
+                "read": "scratch.reference-implementation.tenant",
+                "write": "scratch.reference-implementation.tenant",
+                "partitions": 1,
+                "replication": 3,
+                "partitioner": "default-partitioner",
+                "partitioningDepth": 0,
+                "canRetain": false
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(stream.read(), "scratch.reference-implementation.tenant");
+        assert_eq!(stream.write(), "scratch.reference-implementation.tenant");
     }
 
     #[test]
@@ -837,7 +950,7 @@ mod tests {
                 .unwrap()
                 .read_pattern()
                 .unwrap(),
-            "stream\\.test\\.[^.]*"
+            "^stream\\.test\\.[^.]*"
         );
     }
 

--- a/dsh_sdk/src/datastream/mod.rs
+++ b/dsh_sdk/src/datastream/mod.rs
@@ -733,7 +733,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_deserialization_prepends() {
+    fn test_read_deserialization_without_wildcard() {
         let stream: Stream = serde_json::from_str(
             r#"{
                 "name": "scratch.reference-implementation",

--- a/dsh_sdk/src/datastream/mod.rs
+++ b/dsh_sdk/src/datastream/mod.rs
@@ -712,7 +712,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(stream.read(), "^stream\\.reference-implementation\\.[^.]*");
-        assert_eq!(stream.write(), "stream.reference-implementation.tenant");
     }
 
     #[test]
@@ -733,7 +732,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(stream.read(), "^stream\\.reference-implementation\\.[^.]*");
-        assert_eq!(stream.write(), "stream.reference-implementation.tenant");
     }
 
     #[test]
@@ -754,7 +752,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(stream.read(), "scratch.reference-implementation.tenant");
-        assert_eq!(stream.write(), "scratch.reference-implementation.tenant");
     }
 
     #[test]

--- a/dsh_sdk/src/dsh.rs
+++ b/dsh_sdk/src/dsh.rs
@@ -219,7 +219,10 @@ impl Dsh {
         &self.task_id
     }
 
-    /// Returns the current datastream object (fetched at initialization). This cannot be updated at runtime.
+    /// Returns the [Datastream] object (fetched at initialization of SDK).
+    ///
+    /// This cannot be updated at runtime.
+    /// Use [`fetch_datastream`](Self::fetch_datastream) or [`fetch_datastream_blocking`](Self::fetch_datastream_blocking) to retrieve the latest datastream from DSH.
     pub fn datastream(&self) -> &Datastream {
         self.datastream.as_ref()
     }


### PR DESCRIPTION
- Adds custom deserializer for the read pattern
- Adds examples on how to subscribe with rfkafka
- Adds test to validate deserializer
- Fixed/improved verify_list_of_topics method (noticed it was not completely correct)